### PR TITLE
Mark repository deprecated (1.1.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.1.2] - 2026-06-01
+
+### Changed
+
+- Marked `coinbase-samples/core-java` as deprecated in the README.
+- Documented migration to [coinbase/core-java](https://github.com/coinbase/core-java) and `coinbase-core-java` **1.2.0+** on Maven Central.
+
+### Notes
+
+- No intentional API changes.
+
+## [1.1.1] - 2026-06-01
+
+### Notes
+
+- Prior release published to Maven Central as `com.coinbase.core:coinbase-core-java:1.1.1`.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Coinbase Java Core
 
+The canonical source repository is **[coinbase/core-java](https://github.com/coinbase/core-java)**. The former [coinbase-samples/core-java](https://github.com/coinbase-samples/core-java) repository is deprecated.
+
 [![Maven Central](https://img.shields.io/maven-central/v/com.coinbase.core/coinbase-core-java)](https://central.sonatype.com/artifact/com.coinbase.core/coinbase-core-java)
 [![Javadoc](https://javadoc.io/badge2/com.coinbase.core/coinbase-core-java/latest.svg)](https://javadoc.io/doc/com.coinbase.core/coinbase-core-java)
 
@@ -7,7 +9,7 @@
 
 *Coinbase Java Core* provides a centralized and reusable implementation for making HTTP requests and handling API responses for Coinbase Java SDKs. It includes support for custom headers, credentials, structured error handling, and JSON mapping via Jackson (including JSR-310 date/time types).
 
-**Repository:** [coinbase-samples/core-java](https://github.com/coinbase-samples/core-java)
+**Repository:** [coinbase/core-java](https://github.com/coinbase/core-java)
 
 ## Requirements
 
@@ -87,7 +89,7 @@ If you discover a security vulnerability within this library, please see our [Se
 
 ## 📧 Contact
 
-- [GitHub Issues](https://github.com/coinbase-samples/core-java/issues)
+- [GitHub Issues](https://github.com/coinbase/core-java/issues)
 
 ## Contributing
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <name>Coinbase Java Core</name>
   <description>Core Java Libraries for Sample Applications</description>
   <groupId>com.coinbase.core</groupId>
-  <version>1.1.1</version>
+  <version>1.1.2</version>
   <url>https://github.com/coinbase-samples/core-java</url>
   <licenses>
     <license>


### PR DESCRIPTION
## Summary
- Bump version to 1.1.2
- Add README deprecation banner pointing to coinbase/core-java
- Add CHANGELOG documenting migration to 1.2.0+ on Maven Central

## Test plan
- [ ] README shows canonical repo notice
- [ ] No API/code changes

Made with [Cursor](https://cursor.com)